### PR TITLE
Fixed incorrect reflections in Deferred mode (missing _GBUFFER_NORMALS_OCT)

### DIFF
--- a/Runtime/Shaders/ScreenSpaceReflections.compute
+++ b/Runtime/Shaders/ScreenSpaceReflections.compute
@@ -11,6 +11,7 @@
 
 #pragma multi_compile_local _ USE_MOTION_VECTOR   // TODO: enabled this if URP > 16.0 or exclude for performance.
 #pragma multi_compile_local _ SSR_DEFERRED
+#pragma multi_compile _ _GBUFFER_NORMALS_OCT
 
 // Tweak parameters.
 // #define DEBUG


### PR DESCRIPTION
Fix Summary
Unity 6 (URP 17+) always uses octahedral normal encoding in Deferred mode (`AccurateGbufferNormals = true`).
The `_GBUFFER_NORMALS_OCT` global keyword is set by URP's `DeferredLights`, and `NormalBuffer.hlsl` already has the decode path, but `ScreenSpaceReflections.compute` never declared the keyword.
This caused normals to be decoded as raw RGB instead of octahedral, producing incorrect "distorted" reflection directions in Deferred (and Deferred+) modes in Unity 6000.2+.

Tested and workingn
-Works in Unity 6000.2.0f1 with URP 17.2.0 in Deferred & Deferred+ rendering modes
-Reflections display correctly on smooth surfaces (make sure to dial in your Screen Space Reflection Settings which can make it look pretty bad even with this fix)
-Confirmed no impact on Forward/Forward+ paths

Hope it hjelps others!